### PR TITLE
Sum durations of tests/hooks with the same title

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
-function Tree(title, duration) {
+function Tree(title) {
     this.title = title;
+    this.calls = 0;
     this._children = {};
+}
 
-    if (duration !== undefined) {
-        this._duration = duration;
-    }
+Tree.prototype.addDuration = function (duration) {
+    this.calls += 1;
+    this._duration = (this._duration || 0) + duration;
 }
 
 Tree.prototype.addTest = function (titles, test) {
@@ -12,7 +14,10 @@ Tree.prototype.addTest = function (titles, test) {
 
     // Add a leaf
     if (titles.length === 0) {
-        this._children[test.title] = new Tree(test.title, test.duration);
+        if (!(title in this._children)) {
+            this._children[title] = new Tree(title);
+        }
+        this._children[title].addDuration(test.duration);
         return;
     }
 
@@ -27,7 +32,11 @@ Tree.prototype.addTest = function (titles, test) {
 Tree.prototype.toString = function (indent) {
     indent = indent || '';
 
-    console.log('%d ㎳\t%s%s', this.duration, indent, this.title)
+    if (this.calls > 1) {
+        console.log('%d ㎳\t%s%s (%d calls)', this.duration, indent, this.title, this.calls);
+    } else {
+        console.log('%d ㎳\t%s%s', this.duration, indent, this.title);
+    }
 
     var children = Object.keys(this._children),
         that = this;


### PR DESCRIPTION
Test:
```
describe('Test', function () {
  beforeEach(function (done) {
    setTimeout(done, 100);
  });
  it('test 1', function () {});
  it('test 2', function () {});
});
```

Before:
```
102 ㎳	Whole Suite
102 ㎳	  Test
102 ㎳	    "before each" hook
0 ㎳	    test 1
0 ㎳	    test 2
```

After:
```
212 ㎳	Whole Suite
212 ㎳	  Test
212 ㎳	    "before each" hook (2 calls)
0 ㎳	    test 1
0 ㎳	    test 2
```

Also the hook's parent `Test` and `Whole Suite` durations are now correct.

fixes #3 